### PR TITLE
Remove VS Code hacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,15 +140,7 @@ git clone --recurse-submodules git@github.com:hbthen3rd/dotfiles.git
   - [Gruvbox Theme](https://marketplace.visualstudio.com/items?itemName=jdinhlife.gruvbox)
   - [vscode-icons](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons)
   - [Fluent Icons](https://marketplace.visualstudio.com/items?itemName=miguelsolorio.fluent-icons)
-  - [Apc Customize UI++](https://marketplace.visualstudio.com/items?itemName=drcika.apc-extension)
-    - Allow VSCode to modify itself:
-      ```bash
-      sudo chown -R $(whoami) $(which code)
-      sudo chown -R $(whoami) /Applications/Visual Studio Code.app/Contents/Resources/app/out
-      ```
   - Apply [`settings.json`](/manual-application/VSCode/settings.json)
-  - Open Command Palette by pressing `cmd` + `shift` + `P` > enter `Enable Apc extension` > hit `return`
-  - Quit and restart VSCode
 
 ## Source Control
 

--- a/manual-application/VSCode/settings.json
+++ b/manual-application/VSCode/settings.json
@@ -3,11 +3,6 @@
     "workbench.iconTheme": "vscode-icons",
     "workbench.productIconTheme": "fluent-icons",
 
-    "window.titleBarStyle": "native",
-    "apc.electron": {
-        "frame": false
-    },
-
     "editor.fontFamily": "'Cascadia Code', Menlo, Monaco, 'Courier New', monospace",
     "editor.fontLigatures": true,
     "editor.minimap.autohide": true,


### PR DESCRIPTION
Removing the title bar hacks as the title bar now has useful controls like back/forward, search, layout, etc.